### PR TITLE
distinction of resource access results to weak

### DIFF
--- a/data-ps/ps-ia/ets-ps-ia-bsxets.xml
+++ b/data-ps/ps-ia/ets-ps-ia-bsxets.xml
@@ -12,11 +12,11 @@ Pre-requisite conformance classes:
 <ul><li><a href="http://inspire.ec.europa.eu/id/ats/data/3.0rc3/information-accessibility" target="_blank">Conformance Class 'Information accessibility'</a></li>
 </ul>]]></description>
   <reference>../../inspire-noggeo-bsxets.xq</reference>
-	<version>0.2.0</version>
+	<version>0.2.1</version>
 	<author>interactive instruments GmbH</author>
 	<creationDate>2016-08-15T00:00:00Z</creationDate>
 	<lastEditor>interactive instruments GmbH</lastEditor>
-	<lastUpdateDate>2017-02-21T17:00:00Z</lastUpdateDate>
+	<lastUpdateDate>2017-02-22T13:30:00Z</lastUpdateDate>
 	<tags>
 		<tag ref="EIDb1b53238-efe4-4975-8e2d-a194c20a2e74"/>
 	</tags>
@@ -81,7 +81,7 @@ let $uris :=
 		for $clv in $featuresToInspect/ps:siteDesignation/*/*[self::ps:designationScheme or self::ps:designation]
 			return $clv/@xlink:href) (: $clv/@codeSpace || '/' || $clv/text() :)
 let $urimap := local:check-resource-uris($uris, 30, true())
-let $errorregex := '(notHTTP|idNotFound|EXCEPTION|\d{3})'
+let $errorregex := '(^notHTTP$|^idNotFound$|^EXCEPTION|^\d{3}$)'
 let $featuresWithErrors := if (count($uris)=0) then () else
 	$featuresToInspect[*:siteDesignation/*/*:designationScheme[matches(map:get($urimap,@xlink:href),$errorregex)] or
 		*:siteDesignation/*/*:designation[matches(map:get($urimap,@xlink:href),$errorregex)]][position() le $limitErrors]

--- a/data/information-accessibility/ets-information-accessibility-bsxets.xml
+++ b/data/information-accessibility/ets-information-accessibility-bsxets.xml
@@ -11,11 +11,11 @@ Source: <a href="http://inspire.ec.europa.eu/id/ats/data/3.0rc3/information-acce
 Pre-requisite conformance classes:
 <ul><li><a href="http://inspire.ec.europa.eu/id/ats/data/3.0rc3/schemas" target="_blank">Conformance Class 'INSPIRE GML application schemas'</a></li></ul>]]></description>
 	<reference>../../inspire-bsxets.xq</reference>
-	<version>0.2.0</version>
+	<version>0.2.1</version>
 	<author>interactive instruments GmbH</author>
 	<creationDate>2016-08-15T00:00:00Z</creationDate>
 	<lastEditor>interactive instruments GmbH</lastEditor>
-	<lastUpdateDate>2017-02-21T17:00:00Z</lastUpdateDate>
+	<lastUpdateDate>2017-02-22T13:30:00Z</lastUpdateDate>
 	<tags>
 		<tag ref="EIDaeed5629-2c33-4fa6-aa66-f59418abaa70"/>
 	</tags>
@@ -70,7 +70,7 @@ Source: <a href="http://inspire.ec.europa.eu/id/ats/data/3.0rc3/information-acce
 									<expression>
 let $uris := distinct-values(($features//@srsName,$features//@frame))
 let $urimap := local:check-resource-uris($uris, 30, true())
-let $errorregex := '^(notHTTP|idNotFound|EXCEPTION|\d{3})$'
+let $errorregex := '(^notHTTP$|^idNotFound$|^EXCEPTION|^\d{3}$)'
 let $featuresWithErrors := $features[.//@srsName[matches(map:get($urimap,.),$errorregex)] or .//@frame[matches(map:get($urimap,.),$errorregex)]][position() le $limitErrors]
 return
 (if ($featuresWithErrors) then 'FAILED' else 'PASSED',

--- a/metadata/iso/ets-md-iso-bsxets.xml
+++ b/metadata/iso/ets-md-iso-bsxets.xml
@@ -12,11 +12,11 @@ Source: <a href="http://inspire.ec.europa.eu/id/ats/metadata/1.3/iso-19115-19119
 Pre-requisite conformance classes:
 <ul><li><a href="http://inspire.ec.europa.eu/id/ats/metadata/1.3/xml-encoding" target="_blank">Conformance Class 'XML encoding of ISO 19115/19119 metadata'</a></li></ul>]]></description>
 	<reference>../../inspire-md-bsxets.xq</reference>
-	<version>0.2.0</version>
+	<version>0.2.1</version>
 	<author>interactive instruments GmbH</author>
 	<creationDate>2016-08-30T00:00:00Z</creationDate>
 	<lastEditor>interactive instruments GmbH</lastEditor>
-	<lastUpdateDate>2017-02-21T17:00:00Z</lastUpdateDate>
+	<lastUpdateDate>2017-02-22T13:30:00Z</lastUpdateDate>
 	<tags>
 		<tag ref="EID3b9846c7-3940-4795-ae1d-0b5d82375c76"/>
 	</tags>
@@ -726,7 +726,7 @@ let $messages := (for $record in $recordsToInspect
 	   local:addMessage('TR.idNotFound', map { 'filename': local:filename($record), 'id': $rid, 'url': $url })
     else if (starts-with($validuri, 'EXCEPTION')) then
 		local:addMessage('TR.resourceNotAccessibleException', map { 'filename': local:filename($record), 'id': $rid, 'url': $url, 'message': substring-after($validuri, 'EXCEPTION ') })
-    else if (matches($validuri,'\d{3}')) then
+    else if (matches($validuri,'^\d{3}$')) then
 		local:addMessage('TR.resourceNotAccessible', map { 'filename': local:filename($record), 'id': $rid, 'url': $url, 'status' : $validuri })
     else if (starts-with($validuri,'text/xml') or starts-with($validuri,'application/xml') or starts-with($validuri,'application/vnd.ogc.')) then
       try { 
@@ -1039,7 +1039,7 @@ let $messages := (for $record in $recordsToInspect
 	   local:addMessage('TR.idNotFound', map { 'filename': local:filename($record), 'id': $rid, 'url': $url })
     else if (starts-with($validuri, 'EXCEPTION')) then
 		local:addMessage('TR.resourceNotAccessibleException', map { 'filename': local:filename($record), 'id': $rid, 'url': $url, 'message': substring-after($validuri, 'EXCEPTION ') })
-    else if (matches($validuri,'\d{3}')) then
+    else if (matches($validuri,'^\d{3}$')) then
 		local:addMessage('TR.resourceNotAccessible', map { 'filename': local:filename($record), 'id': $rid, 'url': $url, 'status' : $validuri })
     else if (starts-with($validuri,'text/xml') or starts-with($validuri,'application/xml') or starts-with($validuri,'application/vnd.ogc.')) then
       try { 
@@ -1098,7 +1098,7 @@ let $messages :=
 			local:addMessage('TR.idNotFound', map { 'filename': local:filename($record), 'id': $rid, 'url': $url })
       else if (starts-with($validuri, 'EXCEPTION')) then
 	   	local:addMessage('TR.resourceNotAccessibleException', map { 'filename': local:filename($record), 'id': $rid, 'url': $url, 'message': substring-after($validuri, 'EXCEPTION ') })
-		else if (matches($validuri,'\d{3}')) then
+		else if (matches($validuri,'^\d{3}$')) then
 			local:addMessage('TR.resourceNotAccessible', map { 'filename': local:filename($record), 'id': $rid, 'url': $url, 'status' : $validuri })
 		else if (starts-with($validuri,'text/xml') or starts-with($validuri,'application/xml')) then
 			try { 


### PR DESCRIPTION
\d{3} was matching all cases where a sequence of 3 digits was included
(in this case in the media type), not just the status codes