### PR TITLE
Misc improvements

### DIFF
--- a/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
+++ b/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
@@ -836,13 +836,6 @@
 			</TranslationTemplate>
 		 </translationTemplates>
 	  </LangTranslationTemplateCollection>
-	  <LangTranslationTemplateCollection name="TR.invalidCodeUTF8">
-		 <translationTemplates>
-			<TranslationTemplate language="en" name="TR.invalidCodeUTF8">
-			XML document '{filename}', record '{id}': The MD_CharacterSetCode element with value 'utf8' shall not be provided when it is the only supported encoding. UTF8 is considered as default when MD_CharacterSetCode is not provided. Otherwise, if more than one encoding is supported and UTF8 is one of them, 'utf8' shall be provided.
-			</TranslationTemplate>
-		 </translationTemplates>
-	  </LangTranslationTemplateCollection>
 	  <LangTranslationTemplateCollection name="TR.invalidCrsCode">
 		 <translationTemplates>
 			<TranslationTemplate language="en" name="TR.invalidCrsCode">

--- a/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
+++ b/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
@@ -1475,7 +1475,7 @@ described data set or data set series.
 	  <LangTranslationTemplateCollection name="TR.invalidURL">
 		 <translationTemplates>
 			<TranslationTemplate language="en" name="TR.invalidURL">
-			XML document '{filename}', record '{id}': The provided Resource Locator URL is not working.
+			XML document '{filename}', record '{id}': The provided Resource Locator URL '{url}' is not working.
 			</TranslationTemplate>
 		 </translationTemplates>
 	  </LangTranslationTemplateCollection>

--- a/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
+++ b/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
@@ -1479,6 +1479,13 @@ described data set or data set series.
 			</TranslationTemplate>
 		 </translationTemplates>
 	  </LangTranslationTemplateCollection>
+	  <LangTranslationTemplateCollection name="TR.noLinkageFound">
+		 <translationTemplates>
+			<TranslationTemplate language="en" name="TR.noLinkageFound">
+			XML document '{filename}', record '{id}': No online source element found in the record following the rule '{regex}'.
+			</TranslationTemplate>
+		 </translationTemplates>
+	  </LangTranslationTemplateCollection>
 	  <LangTranslationTemplateCollection name="TR.errorValidatingSchema">
 		 <translationTemplates>
 			<TranslationTemplate language="en" name="TR.errorValidatingSchema">

--- a/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
+++ b/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
@@ -1436,6 +1436,13 @@ described data set or data set series.
 			XML document '{filename}', record '{id}': The encoding code shall be a value from ISO 19139.
 			</TranslationTemplate>
 		 </translationTemplates>
+    </LangTranslationTemplateCollection>
+	  <LangTranslationTemplateCollection name="TR.noValidEncodingCode">
+		 <translationTemplates>
+			<TranslationTemplate language="en" name="TR.noValidEncodingCode">
+			XML document '{filename}', record '{id}': Record contains one or more character set ({charset}) but does not provide any from the ISO19139 list ({validCharset}).
+			</TranslationTemplate>
+		 </translationTemplates>
 	  </LangTranslationTemplateCollection>
 	  <LangTranslationTemplateCollection name="TR.invalidSpatialRepresentationCode">
 		 <translationTemplates>

--- a/metadata/2.0/common/ets-md-common-bsxets.xml
+++ b/metadata/2.0/common/ets-md-common-bsxets.xml
@@ -623,8 +623,8 @@ let $messages :=
 	 return 
 	 	if (not($title)) then local:addMessage('TR.noTitleForThesaurus', map { 'filename': local:filename($record), 'id': $rid})
 	 	else if (not($title/gco:CharacterString/node() or $title/gmx:Anchor/node())) then local:addMessage('TR.emptyTitleForThesaurus', map { 'filename': local:filename($record), 'id': $rid})
-	 	else if (not($date)) then local:addMessage('TR.invalidDateForThesaurus', map { 'filename': local:filename($record), 'id': $rid})
-	 	else if (not($dateTypeCode) or $dateTypeCode/@codeListValue != 'publication') then local:addMessage('TR.invalidDateForThesaurus', map { 'filename': local:filename($record), 'id': $rid})
+	 	else if (not($date)) then local:addMessage('TR.invalidDateForThesaurus', map { 'filename': local:filename($record), 'id': $rid, 'thesaurus': if ($title/*[1]/text() != '') then $title/*[1]/text() else '- Title missing -', 'keywords' : '- Not reported -'})
+	 	else if (not($dateTypeCode) or $dateTypeCode/@codeListValue != 'publication') then local:addMessage('TR.invalidDateForThesaurus', map { 'filename': local:filename($record), 'id': $rid, 'thesaurus': if ($title/*[1]/text() != '') then $title/*[1]/text() else '- Title missing -', 'keywords' : '- Not reported -'})
 	 	else if (not($dateTypeCode) or not(count($dateTypeCode) = count($validCodeList))) then local:addMessage('TR.wrongCodeList', map { 'filename': local:filename($record), 'id': $rid})
 		else ()
 	)[position() le $limitErrors]

--- a/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
+++ b/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
@@ -390,7 +390,7 @@ let $messages :=
 			if (not($url/node())) then
 				local:addMessage('TR.linkageWithoutURL', map { 'filename': local:filename($record), 'id': $rid })
 			else if (not(matches($url/text(), $regex_url))) then
-					local:addMessage('TR.invalidURL', map { 'filename': local:filename($record), 'id': $rid })
+					local:addMessage('TR.invalidURL', map { 'filename': local:filename($record), 'id': $rid, 'url': $url/text()})
 			else ()
 	)[position() le $limitErrors]
 return

--- a/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
+++ b/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
@@ -383,8 +383,12 @@ let $regex_url := '(http://|https://|ftp://)([a-z0-9]{1})((\.[a-z0-9-])|([a-z0-9
 let $messages := 	
 	(for $record in $records
 		let $rid := $record/gmd:fileIdentifier/*/text()
+		let $httpOrFtpLinks := $record/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[matches(gmd:linkage/gmd:URL/text(), $regex_url)]
 		return
-		for $onLine in $record/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource
+		if (count($httpOrFtpLinks) = 0) then
+			local:addMessage('TR.noLinkageFound', map { 'filename': local:filename($record), 'id': $rid, 'regex': $regex_url })
+		else
+		for $onLine in $httpOrFtpLinks
 			let $url := $onLine/gmd:linkage/gmd:URL
 			return
 			if (not($url/node())) then
@@ -403,6 +407,7 @@ return
 										<translationTemplate ref="TR.recordsWithErrors"/>
 										<translationTemplate ref="TR.linkageWithoutURL"/>
 										<translationTemplate ref="TR.invalidURL"/>
+										<translationTemplate ref="TR.noLinkageFound"/>
 									</translationTemplates>
 								</TestAssertion>
 								<TestAssertion id="EIDc7ef6d4f-a03b-4797-85e2-3b4a49e0c5ff">

--- a/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
+++ b/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
@@ -240,7 +240,6 @@ return
 									<expectedResult>NOT_APPLICABLE</expectedResult>
 									<expression>
 let $regex_integer := '(^\d{1,40}$)'
-let $regex_float := '^-?\d+\.\d{2,}'
 let $messages :=
 	(for $record in $records
 		let $countResolutions := count($record/gmd:identificationInfo[1]/*/gmd:spatialResolution)
@@ -254,7 +253,7 @@ let $messages :=
 		let $invalidDistance :=
 			for $x in $record/gmd:identificationInfo[1]/*/gmd:spatialResolution/gmd:MD_Resolution/gmd:distance/gco:Distance
 			return
-			if(matches($x/text(), $regex_float)) then ()
+			if(xs:double($x/text())) then ()
 			else $x
 		let $rid := $record/gmd:fileIdentifier/*/text()
 		return

--- a/metadata/2.0/datasets-and-series/ets-md-isdss-bsxets.xml
+++ b/metadata/2.0/datasets-and-series/ets-md-isdss-bsxets.xml
@@ -266,10 +266,7 @@ let $messages :=
 	(for $record in $records
 		let $rid := $record/gmd:fileIdentifier/*/text()
 		let $characterCodes := $record/gmd:identificationInfo[1]/gmd:MD_DataIdentification/gmd:characterSet/gmd:MD_CharacterSetCode
-		return 	 						
-		if ((count($characterCodes) = 1) and ($characterCodes/@codeListValue) = 'utf8') then
-			local:addMessage('TR.invalidCodeUTF8', map { 'filename': local:filename($record), 'id': $rid })
-		else 			
+		return
 			for $characterCode in $characterCodes
 				let $codeListValue := $characterCode/@codeListValue
 				let $invalidCodeValues := $codeListValue[not(. = $codes)]
@@ -288,7 +285,6 @@ return
 									<testItemType ref="EIDf0edc596-49d2-48d6-a1a1-1ac581dcde0a"/>
 									<translationTemplates>
 										<translationTemplate ref="TR.recordsWithErrors"/>
-										<translationTemplate ref="TR.invalidCodeUTF8"/>
 										<translationTemplate ref="TR.invalidEncodingCode"/>
 										<translationTemplate ref="TR.wrongCodeList"/>
 									</translationTemplates>

--- a/metadata/2.0/datasets-and-series/ets-md-isdss-bsxets.xml
+++ b/metadata/2.0/datasets-and-series/ets-md-isdss-bsxets.xml
@@ -265,17 +265,22 @@ let $codes := ('ucs2','ucs4','utf7','utf8','8859part1','8859part2','8859part3','
 let $messages :=  		
 	(for $record in $records
 		let $rid := $record/gmd:fileIdentifier/*/text()
-		let $characterCodes := $record/gmd:identificationInfo[1]/gmd:MD_DataIdentification/gmd:characterSet/gmd:MD_CharacterSetCode
+    let $allCharacterCodes := $record/gmd:identificationInfo[1]/gmd:MD_DataIdentification/gmd:characterSet/gmd:MD_CharacterSetCode
+		let $characterCodes := $record/gmd:identificationInfo[1]/gmd:MD_DataIdentification/gmd:characterSet/gmd:MD_CharacterSetCode[@codeListValue = $codes]
 		return
-			for $characterCode in $characterCodes
-				let $codeListValue := $characterCode/@codeListValue
-				let $invalidCodeValues := $codeListValue[not(. = $codes)]
-				return
-				if ($invalidCodeValues) then
-					local:addMessage('TR.invalidEncodingCode', map { 'filename': local:filename($record), 'id': $rid})
-				else if (not($characterCode/@codeList = 'http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode')) then
-					local:addMessage('TR.wrongCodeList', map { 'filename': local:filename($record), 'id': $rid })
-				else () 			
+			if (count($allCharacterCodes) = 0) then () (: utf8 is the default. Valid :)
+			else if (count($allCharacterCodes) > 0 and count($characterCodes) = 0) then
+				local:addMessage('TR.noValidEncodingCode', map { 'filename': local:filename($record), 'id': $rid, 'validCharset': string-join($codes, ', '), 'charset': string-join($allCharacterCodes/@codeListValue, ', ')})
+			else
+				for $characterCode in $characterCodes
+					let $codeListValue := $characterCode/@codeListValue
+					let $invalidCodeValues := $codeListValue[not(. = $codes)]
+					return
+					if ($invalidCodeValues) then
+						local:addMessage('TR.invalidEncodingCode', map { 'filename': local:filename($record), 'id': $rid})
+					else if (not($characterCode/@codeList = 'http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode')) then
+						local:addMessage('TR.wrongCodeList', map { 'filename': local:filename($record), 'id': $rid })
+					else ()
 	)[position() le $limitErrors] 
 return
 (if ($messages) then 'FAILED' else 'PASSED',
@@ -285,6 +290,7 @@ return
 									<testItemType ref="EIDf0edc596-49d2-48d6-a1a1-1ac581dcde0a"/>
 									<translationTemplates>
 										<translationTemplate ref="TR.recordsWithErrors"/>
+										<translationTemplate ref="TR.noValidEncodingCode"/>
 										<translationTemplate ref="TR.invalidEncodingCode"/>
 										<translationTemplate ref="TR.wrongCodeList"/>
 									</translationTemplates>


### PR DESCRIPTION
Based on testing of the TG2 validation with EEA (@jmrubio82), we have some feedback & bugfix regarding the current validation rules. This PR describes different changes for discussion. You may want cherry-pick only the one that sounds relevant.


## md common req C.15: Keyword Originating CV

Message is:
```
XML document 'file.xml', record 'c651bc41-d5da-49de-ba47-c51eabbb2007': 
The metadata record has keywords which originate from a controlled vocabulary 
'{thesaurus}', but no date of publication, creation, or revision is provided. 
The keywords are: {keywords}.
```
Solve thesaurus placeholder replacement (https://github.com/inspire-eu-validation/ets-repository/commit/3f2573cbb77be7a2ddc2e52f63a03faf188706b3)

## Character encoding / utf8 the only and default is not valid, one valid + another is not valid

The following
```xml
         <gmd:characterSet>
            <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"
                                     codeListValue="utf8"/>
         </gmd:characterSet>
         <gmd:characterSet>
            <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"
                                     codeListValue="Braille_ASCII"/>
         </gmd:characterSet>
```
should be considered valid ?

Improved message with better explanation of what is expected. Eg if only Braille_ASCII is set
```
XML document 'file.xml', record 'c651bc41-d5da-49de-ba47-c51eabbb2007':
 Record contains one or more character set (Braille_ASCII) but does not provide 
any from the ISO19139 list (ucs2, ucs4, utf7, utf8, 8859part1, 8859part2, 8859part3,
 8859part4, 8859part5, 8859part6, 8859part7, 8859part8, 8859part9, 8859part10,
 8859part11, 8859part12, 8859part13, 8859part14, 8859part15, 8859part16, jis, 
shiftJIS, eucJP, usAscii, eucKR, big5, GB2312).
```

## Invalid URL

Current rule expect that all URL are following a regex for URL format.

eg. 
```xml
<gmd:onLine gco:nilReason="withheld">
                  <gmd:CI_OnlineResource>
                     <gmd:linkage>
                        <gmd:URL>pg:gis_sdi/urban_atlas.nl012l_breda</gmd:URL>
                     </gmd:linkage>
                     <gmd:protocol>
                        <gco:CharacterString>EEA:DB</gco:CharacterString>
                     </gmd:protocol>
```

“A Resource locator linking to the service(s) providing online access to the described data set or data set series shall be given, if such online access is available.”

This does not mean that all gmd:onLine/gmd:URL have to be “valid” URLs according to the TG ?

The test may be a bit restricted vision on what a URL can be (eg. https://en.wikipedia.org/wiki/URL). `file://` or `jdbc://`… are valid URL. In the case above, file path starting with a “/” which points to LAN folder is indeed not really a URL, same for `pg:` .... BTW. Protocol Relative URL starting with ‘//’ could also be considered valid.

The test can maybe check that at least one URL is following the pattern and “The Resource Locator is the ‘navigation section’ of a metadata record which point users to the location (URL) where the data can be downloaded, or to where additional information about the resource may be provided.“ and let users do what they want with the others ?

Other improvement: Add some context so that the end user knows what is the URL tested https://github.com/fxprunayre/ets-repository/commit/0e9151e8cff78af95a51bc761d70405a81f2abd3 
```
XML document 'file.xml', record 'c651bc41-d5da-49de-ba47-c51eabbb2007':
 The provided Resource Locator URL 
'/local/tr/geography/eea_ref_grids/eea_v_3035_100_km_eea-ref-grid-tr_2011/tr_100km.shp'
 is not working.
```


## Spatial resolution


```xml
         <gmd:spatialResolution>
            <gmd:MD_Resolution>
               <gmd:distance>
                  <gco:Distance uom="https://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/ML_gmxUom.xml#m">100000</gco:Distance>
               </gmd:distance>
```

Error reported:
```
XML document 'file.xml', record 'c651bc41-d5da-49de-ba47-c51eabbb2007': The distance shall be a float number and 
shall not be empty. Found: 100000
```

Replacing by ```100000.000``` works!

An XSD parser valid integer value for double. It also valid scientific notation like `100000e4`. `INF` is also fine. It complains about non numeric.
`Invalid or missing value. '100000AAA' is not a valid value for (double) in element Distance (gmd:distance).`

`gco:Distance` is a double.
http://www.wmo.int/schemas/wmdr/1.0RC7/documentation/schemadoc/schemas/basicTypes_xsd_1/elements/Distance.html

XSD double is defined as https://www.w3.org/TR/xmlschema11-2/#double

So using regex `'^-?\d+\.\d{2,}'` sounds a bit restrictive to what a double is.

Using cast to double. If failure, then reports
`[err:FORG0001] Cannot cast to xs:double: DADA.`

Cast to double instead of using a hand made regex https://github.com/fxprunayre/ets-repository/commit/8806b2ea44acc8f92963a4feac4eff4de00fd2b7


## Thesaurus date

```xml
<gmd:thesaurusName>
                  <gmd:CI_Citation>
                     <gmd:title>
                        <gco:CharacterString>EEA keyword list</gco:CharacterString>
                     </gmd:title>
                     <gmd:date>
                        <gmd:CI_Date>
                           <gmd:date>
                              <gco:Date>2002-03-01</gco:Date>
                           </gmd:date>
                           <gmd:dateType>
                              <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
                                                   codeListValue="creation"/>
```

Does it make sense to check that date type is publication for all thesaurus ? This could be done only for INSPIRE related thesaurs ?

