### PR TITLE
md common req C.5: Language Code / Valid codelist value are always reported as invalid

### DIFF
--- a/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
+++ b/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
@@ -1556,7 +1556,7 @@ In other cases, gmd:otherConstraints shall include a non-empty free text element
 	  <LangTranslationTemplateCollection name="TR.wrongCodeList_Param">
 		 <translationTemplates>
 		    <TranslationTemplate language="en" name="TR.wrongCodeList_Param">
-			XML document '{filename}', record '{id}': The code list attribute is not correct. The attribute code list shall be '{param}'
+			XML document '{filename}', record '{id}': The code list attribute is not correct. The attribute code list shall be '{param}'. The current value is '{invalidValue}'.
 			</TranslationTemplate>
 		 </translationTemplates>
 	  </LangTranslationTemplateCollection>

--- a/metadata/2.0/common/ets-md-common-bsxets.xml
+++ b/metadata/2.0/common/ets-md-common-bsxets.xml
@@ -147,8 +147,8 @@ Source: <a href="http://inspire.ec.europa.eu/id/ats/metadata/2.0/common" target=
 											local:addMessage('TR.noLanguageCode',  map { 'filename': local:filename($record), 'id': $rid })
 										else if (count($languageCodes) != 1) then
 											local:addMessage('TR.wrongLanguageCodeNumber',  map { 'filename': local:filename($record), 'id': $rid })
-										else if ($languageCodes/@codeList != 'http://www.loc.gov/standards/iso639-2/' or $languageCodes/@codeList != 'http://www.loc.gov/standards/iso639-2') then
-											local:addMessage('TR.wrongCodeList_Param',  map { 'filename': local:filename($record), 'id': $rid, 'param': 'http://www.loc.gov/standards/iso639-2/'})
+										else if ($languageCodes/@codeList != 'http://www.loc.gov/standards/iso639-2/' and $languageCodes/@codeList != 'http://www.loc.gov/standards/iso639-2') then
+											local:addMessage('TR.wrongCodeList_Param',  map { 'filename': local:filename($record), 'id': $rid, 'param': 'http://www.loc.gov/standards/iso639-2/', 'invalidValue': string($languageCodes/@codeList)})
 										else if ($languageCodes/@codeListValue[not(. = $codes)]) then
 											local:addMessage('TR.invalidLanguageCode',  map { 'filename': local:filename($record), 'id': $rid, 'invalidCodes' : $languageCodes/@codeListValue/string()})
 										else ()
@@ -204,7 +204,6 @@ Source: <a href="http://inspire.ec.europa.eu/id/ats/metadata/2.0/common" target=
 											<translationTemplate ref="TR.noMetadataContactOrganisationName"/>
 											<translationTemplate ref="TR.noMetadataContactEmailAddress"/>
 											<translationTemplate ref="TR.noMetadataContactRole"/>
-											<translationTemplate ref="TR.wrongCodeList_Param"/>
 											<translationTemplate ref="TR.recordsWithErrors"/>
 										</translationTemplates>
 									</TestAssertion>

--- a/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
+++ b/metadata/2.0/datasets-and-series/ets-md-datasets-and-series-bsxets.xml
@@ -305,7 +305,7 @@ let $messages :=
 			if ($wrongCodeValues) then
 				local:addMessage('TR.invalidLanguageCode',  map { 'filename': local:filename($record), 'id': $rid, 'invalidCodes' : string-join($wrongCodeValues,', ') })
 			else if($wrongCodeList) then
-				local:addMessage('TR.wrongCodeList_Param',  map { 'filename': local:filename($record), 'id': $rid, 'param': 'http://www.loc.gov/standards/iso639-2/'})
+				local:addMessage('TR.wrongCodeList_Param',  map { 'filename': local:filename($record), 'id': $rid, 'param': 'http://www.loc.gov/standards/iso639-2/', 'invalidValue': string($wrongCodeList)})
 			else ()     	
 	)[position() le $limitErrors]
 return


### PR DESCRIPTION
Introduced in
https://github.com/inspire-eu-validation/ets-repository/commit/5b75bc7931f9d4f4f58d2505b05f463b306c1de7

* Fix the codelist check that is probably supposed to allow both values (ie. with or without final `/`)
* Improve error reporting the invalid value to be checked

![image](https://user-images.githubusercontent.com/1701393/62354243-ae4c9400-b50c-11e9-8032-3cecb02713ea.png)
