### PR TITLE
noDateTypeForSpecification message typo fixed

### DIFF
--- a/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
+++ b/include-metadata/TranslationTemplateBundle-EID70a263c0-0ad7-42f2-9d4d-0d8a4ca71b52.xml
@@ -492,7 +492,7 @@
 		</LangTranslationTemplateCollection>
 		<LangTranslationTemplateCollection name="TR.noDateTypeForSpecification">
 			<translationTemplates>
-				<TranslationTemplate language="en" name="TR.noDateTypeForSpecification">XML document '{filename}', record '{id}': The metadata record contains a reference to a specification, but no dateType of 'creation', 'revision', or 'publication' is provided for it.</TranslationTemplate>
+				<TranslationTemplate language="en" name="TR.noDateTypeForSpecification">XML document '{filename}', record '{id}': The metadata record contains a reference to a specification, but the codeListValue or date type is not correct. The codeListValue or date type should be 'publication'.</TranslationTemplate>
 			</translationTemplates>
 		</LangTranslationTemplateCollection>
 		<LangTranslationTemplateCollection name="TR.noSpecifications">


### PR DESCRIPTION
Corresponding issue: [#601](https://github.com/INSPIRE-MIF/helpdesk-validator/issues/601)