### PR TITLE
HTTP response headers in all services should be case insensitive

### DIFF
--- a/service/dis-csw-core-soapui-project.xml
+++ b/service/dis-csw-core-soapui-project.xml
@@ -1480,8 +1480,10 @@ for (i in languages_to_request){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	if (ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type', 'value').contains('xml')){
-		validContentType = true;
+	for (j in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
+		if (j.contains('xml')){
+			validContentType = true;
+		}
 	}
 	if(!validContentType){
 		throw new TranslatableAssertionError("TR.notXMLResponse");
@@ -1602,8 +1604,10 @@ for (i in languages_to_request){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	if (ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type', 'value').contains('xml')){
-		validContentType = true;
+	for (j in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
+		if (j.contains('xml')){
+			validContentType = true;
+		}
 	}
 	if(!validContentType){
 		throw new TranslatableAssertionError("TR.notXMLResponse");

--- a/service/vs-wms-soapui-project.xml
+++ b/service/vs-wms-soapui-project.xml
@@ -2308,7 +2308,7 @@ for (x in supportedLanguages){
 					testRunner.testCase.setPropertyValue('legendEndpoint', style.LegendURL.OnlineResource.@'xlink:href'.toString());
 					tsGetLegend.setDisabled(false);
 					tsGetLegend.run(testRunner, context);
-					if(tsGetLegend.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type', 'value') != style.LegendURL.Format.toString()){
+					if(tsGetLegend.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')[0] != style.LegendURL.Format.toString()){
 						String[] assertParams = ['Content-Type', tsGetLegend.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type', 'value'), 'LegendURL', style.LegendURL.Format.toString()];
 						throw new TranslatableAssertionError("TR.invalidLegendFormat", assertParams);
 					}
@@ -5441,8 +5441,10 @@ if(defaultLanguage in isoLang){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	if (ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type', 'value').contains('xml')){
-		validContentType = true;
+	for (i in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
+		if (i.contains('xml')){
+			validContentType = true;
+		}
 	}
 	if(!validContentType){
 		throw new TranslatableAssertionError("TR.notXMLResponse");

--- a/service/vs-wmts-soapui-project.xml
+++ b/service/vs-wmts-soapui-project.xml
@@ -1117,12 +1117,14 @@ layers.each{layer->
 
 				def httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 
-				if(httpResponseHeaders.containsKeyIgnoreCase('Content-Type') &amp;&amp; httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') != format.toString()){
+				if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') != null &amp;&amp; httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') !=  format.toString()){
+
 					def identifier_tmp = '';
 					if(layer.Identifier.size() == 1){
 						identifier_tmp = layer.Identifier.toString();
 					}
 					String[] assertParams = ["responseformat", httpResponseHeaders.getCaseInsensitive('Content-Type', 'value'), "requestedformat", format.toString(), "layerid", identifier_tmp];
+
 
 					throw new TranslatableAssertionError("TR.wrongResponseFormat", assertParams);
 					//Msg: The response format ({responseformat}) is distinct to the requested format ({requestedformat}) for the '{layerid}' layer.

--- a/service/vs-wmts-soapui-project.xml
+++ b/service/vs-wmts-soapui-project.xml
@@ -1123,6 +1123,7 @@ layers.each{layer->
 						identifier_tmp = layer.Identifier.toString();
 					}
 					String[] assertParams = ["responseformat", httpResponseHeaders.getCaseInsensitive('Content-Type', 'value'), "requestedformat", format.toString(), "layerid", identifier_tmp];
+
 					throw new TranslatableAssertionError("TR.wrongResponseFormat", assertParams);
 					//Msg: The response format ({responseformat}) is distinct to the requested format ({requestedformat}) for the '{layerid}' layer.
 				}


### PR DESCRIPTION
Corresponding issue [#558](https://github.com/INSPIRE-MIF/helpdesk-validator/issues/558)