### PR TITLE
HTTP response headers in services are case insensitive

### DIFF
--- a/service/dis-csw-core-soapui-project.xml
+++ b/service/dis-csw-core-soapui-project.xml
@@ -1301,7 +1301,7 @@ for (i in languages_to_request){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	for (j in ts.testRequest.response.responseHeaders.get('Content-Type')){
+	for (j in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
 		if (j.contains('xml')){
 			validContentType = true;
 		}
@@ -1425,7 +1425,7 @@ for (i in languages_to_request){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	for (j in ts.testRequest.response.responseHeaders.get('Content-Type')){
+	for (j in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
 		if (j.contains('xml')){
 			validContentType = true;
 		}

--- a/service/ds-sos-pre-defined-soapui-project.xml
+++ b/service/ds-sos-pre-defined-soapui-project.xml
@@ -64,7 +64,7 @@ tsGetObservation.setDisabled(true);
 					<con:assertion type="OwsExceptionReportAssertion" id="136249b8-9f81-4761-be97-74c831c7ad62" name="Fail if service returns OWS Exception Report" />
 					<con:assertion type="GroovyScriptAssertion" id="bbf2023a-6f68-45c7-aec4-620da5a8643a" name="check-content-type">
 						<con:configuration>
-							<scriptText>assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml'));</scriptText>
+							<scriptText>assert (messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml'));</scriptText>
 						</con:configuration>
 					</con:assertion>
 					<con:credentials>

--- a/service/vs-wms-soapui-project.xml
+++ b/service/vs-wms-soapui-project.xml
@@ -2456,7 +2456,7 @@ def format_response = httpResponseHeaders["Content-Type"][0];
 assert (format_requested == format_response);
 */
 def format_requested = context.expand( '${#TestSuite#format}' );
-assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contains(format_requested));</scriptText>
+assert (messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains(format_requested));</scriptText>
 						</con:configuration>
 					</con:assertion>
 					<con:assertion type="Response SLA Assertion" id="51e0114d-be2f-496c-9e71-f23c9e408f47" name="Response SLA">
@@ -2560,7 +2560,7 @@ assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contai
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'VERSION'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -2674,7 +2674,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'VERSION'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -2813,7 +2813,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'REQUEST'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -2927,7 +2927,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'REQUEST'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -3066,7 +3066,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'LAYERS'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -3180,7 +3180,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'LAYERS'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -3319,7 +3319,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'STYLES'];
-if(!(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('image'))){
+if(!(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('image'))){
 	throw new TranslatableAssertionError('TR.getMapResponseWithEmptyStyleParameterNotImage', assertParams);
 }
 							</scriptText>
@@ -3436,7 +3436,7 @@ if(!(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains(
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'STYLES'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -3550,7 +3550,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'STYLES'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -3689,7 +3689,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'CRS'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -3779,7 +3779,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'CRS'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -3888,7 +3888,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'BBOX'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -4002,7 +4002,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'BBOX'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -4141,7 +4141,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'WIDTH AND HEIGHT'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -4223,7 +4223,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'WIDTH AND HEIGHT'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -4342,7 +4342,7 @@ if(format.length() == 0){
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'FORMAT'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapNoMandatoryParameterNotFail", assertParams);
@@ -4429,7 +4429,7 @@ else{
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'FORMAT'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -4538,7 +4538,7 @@ else{
 					<con:assertion type="GroovyScriptAssertion" id="0f443084-c9bb-4f7a-b166-6e5442e27aa4" name="check-content-type">
 						<con:configuration>
 							<scriptText>def format_requested = context.expand( '${#TestSuite#format}' );
-assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contains(format_requested));</scriptText>
+assert (messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains(format_requested));</scriptText>
 						</con:configuration>
 					</con:assertion>
 					<con:assertion type="Response SLA Assertion" id="27711021-2cc1-4c4b-bf4d-ee985c844a59" name="Response SLA">
@@ -4627,7 +4627,7 @@ assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contai
 					<con:assertion type="GroovyScriptAssertion" id="fa2519c2-2103-49ec-b848-d5f48bb76754" name="check-content-type">
 						<con:configuration>
 							<scriptText>def format_requested = context.expand( '${#TestSuite#format}' );
-assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contains(format_requested));</scriptText>
+assert (messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains(format_requested));</scriptText>
 						</con:configuration>
 					</con:assertion>
 					<con:assertion type="Response SLA Assertion" id="5c7ec18d-ad6b-4e25-9d25-a32a9e8a0a2c" name="Response SLA">
@@ -4722,7 +4722,7 @@ assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contai
 						<con:configuration>
 							<scriptText>import de.interactive_instruments.etf.suim.TranslatableAssertionError;
 String[] assertParams = ['parameter', 'TRANSPARENT'];
-if(messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml')){
+if(messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml')){
 	def xml_root = new XmlSlurper().parseText(messageExchange.response.responseContent);
 	if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 		throw new TranslatableAssertionError("TR.getMapWrongParameterNotFail", assertParams);
@@ -4834,7 +4834,7 @@ else{
 					</con:assertion>
 					<con:assertion type="GroovyScriptAssertion" id="bb257502-6c92-4221-929d-c6a3cb82d8f0" name="check-content-type-xml">
 						<con:configuration>
-							<scriptText>assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml'));</scriptText>
+							<scriptText>assert (messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml'));</scriptText>
 						</con:configuration>
 					</con:assertion>
 					<con:assertion type="Response SLA Assertion" id="485bd526-d5de-4128-8011-caa561db7fe9" name="Response SLA">
@@ -4916,7 +4916,7 @@ else{
 					</con:assertion>
 					<con:assertion type="GroovyScriptAssertion" id="2a92e656-ead8-47d7-88fc-c5d9db329c1d" name="check-content-type-xml">
 						<con:configuration>
-							<scriptText>assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml'));</scriptText>
+							<scriptText>assert (messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml'));</scriptText>
 						</con:configuration>
 					</con:assertion>
 					<con:assertion type="Response SLA Assertion" id="5f2f3838-6d8d-4fe9-aabc-f19513dac239" name="Response SLA">

--- a/service/vs-wms-soapui-project.xml
+++ b/service/vs-wms-soapui-project.xml
@@ -2300,7 +2300,7 @@ for (x in supportedLanguages){
 					testRunner.testCase.setPropertyValue('legendEndpoint', style.LegendURL.OnlineResource.@'xlink:href'.toString());
 					tsGetLegend.setDisabled(false);
 					tsGetLegend.run(testRunner, context);
-					if(tsGetLegend.testRequest.response.responseHeaders.get('Content-Type')[0] != style.LegendURL.Format.toString()){
+					if(tsGetLegend.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')[0] != style.LegendURL.Format.toString()){
 						String[] assertParams = ['Content-Type', tsGetLegend.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type', 'value'), 'LegendURL', style.LegendURL.Format.toString()];
 						throw new TranslatableAssertionError("TR.invalidLegendFormat", assertParams);
 					}
@@ -5433,7 +5433,7 @@ if(defaultLanguage in isoLang){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	for (i in ts.testRequest.response.responseHeaders.get('Content-Type')){
+	for (i in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
 		if (i.contains('xml')){
 			validContentType = true;
 		}

--- a/service/vs-wmts-soapui-project.xml
+++ b/service/vs-wmts-soapui-project.xml
@@ -601,7 +601,7 @@ requestStepList.each{reqStep->
 	
 		httpResponseHeaders = context.testCase.testSteps[reqStep].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
 	
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			
@@ -628,7 +628,7 @@ requestStepList.each{reqStep->
 	
 		httpResponseHeaders = context.testCase.testSteps[reqStep].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 				String[] assertParams = ["parameter", param.toString()];
@@ -1117,12 +1117,12 @@ layers.each{layer->
 
 				def httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 
-				if(httpResponseHeaders["Content-Type"][0] != null &amp;&amp; httpResponseHeaders["Content-Type"][0] !=  format.toString()){
+				if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value') != null &amp;&amp; httpResponseHeaders.getCaseInsensitive(Content-Type', 'value') !=  format.toString()){
 					def identifier_tmp = '';
 					if(layer.Identifier.size() == 1){
 						identifier_tmp = layer.Identifier.toString();
 					}
-					String[] assertParams = ["responseformat", httpResponseHeaders["Content-Type"][0].toString(), "requestedformat", format.toString(), "layerid", identifier_tmp];
+					String[] assertParams = ["responseformat", httpResponseHeaders.getCaseInsensitive(Content-Type', 'value'), "requestedformat", format.toString(), "layerid", identifier_tmp];
 					throw new TranslatableAssertionError("TR.wrongResponseFormat", assertParams);
 					//Msg: The response format ({responseformat}) is distinct to the requested format ({requestedformat}) for the '{layerid}' layer.
 				}
@@ -1960,7 +1960,7 @@ supportedLangs.each{lang->
 	
 				httpResponseHeaders = context.testCase.testSteps["http-request-legend"].testRequest.response.responseHeaders;
 	
-				if(httpResponseHeaders["Content-Type"][0].toString() != format.toString()){
+				if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value') != format.toString()){
 					String[] assertParams = ["styleid", style.Identifier.toString(), "layerid", layer.Identifier.toString()];
 					throw new TranslatableAssertionError("TR.wrongLegendResponseFormat", assertParams);
 					//Msg: The response format is wrong for the legend resource into the '{styleid}' style into the '{layerid}' layer.
@@ -2184,7 +2184,7 @@ if(testRunner.testCase.testSuite.project.getPropertyValue("defaultGetTile_Endpoi
 	
 		httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
 	
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			
@@ -2211,7 +2211,7 @@ if(testRunner.testCase.testSuite.project.getPropertyValue("defaultGetTile_Endpoi
 	
 		httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 				String[] assertParams = ["parameter", param.toString()];

--- a/service/vs-wmts-soapui-project.xml
+++ b/service/vs-wmts-soapui-project.xml
@@ -601,7 +601,7 @@ requestStepList.each{reqStep->
 	
 		httpResponseHeaders = context.testCase.testSteps[reqStep].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
 	
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			
@@ -628,7 +628,7 @@ requestStepList.each{reqStep->
 	
 		httpResponseHeaders = context.testCase.testSteps[reqStep].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 				String[] assertParams = ["parameter", param.toString()];
@@ -1117,12 +1117,12 @@ layers.each{layer->
 
 				def httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 
-				if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value') != null &amp;&amp; httpResponseHeaders.getCaseInsensitive(Content-Type', 'value') !=  format.toString()){
+				if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') != null &amp;&amp; httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') !=  format.toString()){
 					def identifier_tmp = '';
 					if(layer.Identifier.size() == 1){
 						identifier_tmp = layer.Identifier.toString();
 					}
-					String[] assertParams = ["responseformat", httpResponseHeaders.getCaseInsensitive(Content-Type', 'value'), "requestedformat", format.toString(), "layerid", identifier_tmp];
+					String[] assertParams = ["responseformat", httpResponseHeaders.getCaseInsensitive('Content-Type', 'value'), "requestedformat", format.toString(), "layerid", identifier_tmp];
 					throw new TranslatableAssertionError("TR.wrongResponseFormat", assertParams);
 					//Msg: The response format ({responseformat}) is distinct to the requested format ({requestedformat}) for the '{layerid}' layer.
 				}
@@ -1960,7 +1960,7 @@ supportedLangs.each{lang->
 	
 				httpResponseHeaders = context.testCase.testSteps["http-request-legend"].testRequest.response.responseHeaders;
 	
-				if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value') != format.toString()){
+				if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') != format.toString()){
 					String[] assertParams = ["styleid", style.Identifier.toString(), "layerid", layer.Identifier.toString()];
 					throw new TranslatableAssertionError("TR.wrongLegendResponseFormat", assertParams);
 					//Msg: The response format is wrong for the legend resource into the '{styleid}' style into the '{layerid}' layer.
@@ -2184,7 +2184,7 @@ if(testRunner.testCase.testSuite.project.getPropertyValue("defaultGetTile_Endpoi
 	
 		httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
 	
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			
@@ -2211,7 +2211,7 @@ if(testRunner.testCase.testSuite.project.getPropertyValue("defaultGetTile_Endpoi
 	
 		httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive(Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 				String[] assertParams = ["parameter", param.toString()];


### PR DESCRIPTION
Corresponding issue: [#558](https://github.com/INSPIRE-MIF/helpdesk-validator/issues/558)