### PR TITLE
Predefined ATOM source links changed to master

### DIFF
--- a/service/ds-atom-pre-defined-soapui-project.xml
+++ b/service/ds-atom-pre-defined-soapui-project.xml
@@ -12,7 +12,7 @@ Please report any issues or problems <a href="https://github.com/INSPIRE-MIF/hel
 <br/> <br/>
 Known limitations are documented in the description of the applicable test case or test assertion.
 <br/> <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined" target="_blank">Conformance Class 'Pre-defined Atom'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined" target="_blank">Conformance Class 'Pre-defined Atom'</a>]]>
 	</con:description>
 	<con:settings />
 	<con:testSuite name="Initialization and basic checks" id="6266de5b-169b-4933-896b-803260ff568e">
@@ -210,7 +210,7 @@ and email address shall be provided as contact information.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-contact-information" target="_blank">Abstract Test Case 'Download Service feed contact information'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-contact-information" target="_blank">Abstract Test Case 'Download Service feed contact information'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="Initialization and basic checks" id="7d695871-e4c6-4360-a562-8d2da96ba906">
@@ -291,7 +291,7 @@ a well-known definition of a coordinate reference system.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-crs-information" target="_blank">Abstract Test Case 'Download Service feed CRS information'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-crs-information" target="_blank">Abstract Test Case 'Download Service feed CRS information'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="calltestcase" name="Initialization and basic checks" id="40bb7f94-25d8-462b-ab3f-975a7402bde0">
@@ -394,7 +394,7 @@ of the feed.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-dataset-identifiers" target="_blank">Abstract Test Case 'Download Service feed dataset identifiers'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-dataset-identifiers" target="_blank">Abstract Test Case 'Download Service feed dataset identifiers'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="calltestcase" name="Initialization and basic checks" id="de6d0b18-45fe-4795-a4d6-ffe08ae08b4f">
@@ -504,7 +504,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-id" target="_blank">Abstract Test Case 'Download Service feed: id'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-id" target="_blank">Abstract Test Case 'Download Service feed: id'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="calltestcase" name="Initialization and basic checks" id="d3d7d1e5-47cb-4624-ad67-076cf69538ac">
@@ -690,7 +690,7 @@ identifier for that feed entry.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-identifiers" target="_blank">Abstract Test Case 'Download Service feed identifiers'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-identifiers" target="_blank">Abstract Test Case 'Download Service feed identifiers'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="calltestcase" name="Initialization and basic checks" id="5404b3db-ed62-40ca-990b-6a5a7ba58574">
@@ -794,7 +794,7 @@ document.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-link-opensearch-description-document" target="_blank">Abstract Test Case 'Download Service feed: link OpenSearch Description document'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-link-opensearch-description-document" target="_blank">Abstract Test Case 'Download Service feed: link OpenSearch Description document'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="calltestcase" name="Initialization and basic checks" id="3d5c4205-a68c-4d85-9483-0cc734eca54f">
@@ -992,7 +992,7 @@ value 'application/xml'</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-wfs-link" target="_blank">Abstract Test Case 'Download Service feed: link to WFS Capabilities document'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-wfs-link" target="_blank">Abstract Test Case 'Download Service feed: link to WFS Capabilities document'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="calltestcase" name="Initialization and basic checks" id="0a1d5f53-3f92-45bc-9f1d-8a6512e64f9a">
@@ -1091,7 +1091,7 @@ Dataset metadata record. This link shall have a 'rel' attribute with a value of
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-links-dataset-metadata-records" target="_blank">Abstract Test Case 'Download Service feed links dataset metadata records'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-links-dataset-metadata-records" target="_blank">Abstract Test Case 'Download Service feed links dataset metadata records'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Service Feed" id="1b3fcafb-e884-4894-994c-60e9ca525c83">
@@ -1156,7 +1156,7 @@ restrictions for that feed.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-rights-element" target="_blank">Abstract Test Case 'Download Service feed rights element'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-rights-element" target="_blank">Abstract Test Case 'Download Service feed rights element'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Service Feed" id="c0e89d68-2fb5-49e6-a001-cfdfe37ac91d">
@@ -1223,7 +1223,7 @@ be 'application/atom+xml', 'application/xml' or 'text/xml.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.2/atom-pre-defined/download-service-feed-self-reference-link" target="_blank">Abstract Test Case 'Download Service feed: self-reference link'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-self-reference-link" target="_blank">Abstract Test Case 'Download Service feed: self-reference link'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="calltestcase" name="OpenSearch Description link exists" id="07e52606-e155-4314-9ddd-9f1b498690be">
@@ -1326,7 +1326,7 @@ populated with a human readable title for the feed entry.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-entry-titles" target="_blank">Abstract Test Case 'Download Service feed: entry titles'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-entry-titles" target="_blank">Abstract Test Case 'Download Service feed: entry titles'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Service Feed" id="247f8881-c8e2-462d-a999-96144faee1f3">
@@ -1387,7 +1387,7 @@ contain the date, time and timezone at which the feed entry was last updated.</l
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-updated-element-date" target="_blank">Abstract Test Case 'Download Service feed updated element date'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-updated-element-date" target="_blank">Abstract Test Case 'Download Service feed updated element date'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Service Feed" id="f590f109-ddde-4c22-8f11-1beedc7628d5">
@@ -1475,7 +1475,7 @@ which the feed was last updated.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-updated-element" target="_blank">Abstract Test Case 'Download Service feed updated element'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-updated-element" target="_blank">Abstract Test Case 'Download Service feed updated element'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Service Feed" id="236bb0dd-3eda-46cd-83c4-7cc7f2fd5b3a">
@@ -1565,7 +1565,7 @@ title for the feed.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-title" target="_blank">Abstract Test Case 'Download service feed: Provide a title element'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-title" target="_blank">Abstract Test Case 'Download service feed: Provide a title element'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Service Feed" id="c5359a5b-67d8-4b76-aa50-1db7b317029f">
@@ -1626,7 +1626,7 @@ datasets as individual entries within an Atom feed.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/download-service-feed-entry-per-dataset" target="_blank">Abstract Test Case 'Download service feed: separate entries per dataset'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-entry-per-dataset" target="_blank">Abstract Test Case 'Download service feed: separate entries per dataset'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="Test Case Dependency" id="71933598-4183-43b0-8ba7-cd280b7b59eb">
@@ -1700,7 +1700,7 @@ and a 'type' attribute with a value 'application/atom+xml' or 'application/xml' 
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.2/atom-pre-defined/download-service-feed-links-dataset-feed" target="_blank">Abstract Test Case 'Download Service feed links dataset feed'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/download-service-feed-links-dataset-feed" target="_blank">Abstract Test Case 'Download Service feed links dataset feed'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Service Feed" id="dafcef94-9aa0-44aa-815b-5966d1813b17">
@@ -2246,7 +2246,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-contact-information" target="_blank">Abstract Test Case 'Dataset feed contact information'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-contact-information" target="_blank">Abstract Test Case 'Dataset feed contact information'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="Initialization and basic checks passed" id="6911c18d-4c5b-4d61-bb81-13c1d8f6e591">
@@ -2325,7 +2325,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-id" target="_blank">Abstract Test Case 'Dataset feed HTTP URI'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-id" target="_blank">Abstract Test Case 'Dataset feed HTTP URI'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="2aa9841c-d552-45fe-b35a-d4b1659a3855">
@@ -2457,7 +2457,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-link-download-dataset" target="_blank">Abstract Test Case 'Link download dataset'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-link-download-dataset" target="_blank">Abstract Test Case 'Link download dataset'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="013a9576-bdf0-4f2c-8521-6e50e3a10ab3">
@@ -2605,7 +2605,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-rights-element" target="_blank">Abstract Test Case 'Rights element'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-rights-element" target="_blank">Abstract Test Case 'Rights element'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="fb0b0344-5d6b-4293-8839-b249ddc9fbee">
@@ -2660,7 +2660,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-title" target="_blank">Abstract Test Case 'Title'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-title" target="_blank">Abstract Test Case 'Title'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="bab92e23-e681-41e9-980f-59794067365d">
@@ -2713,7 +2713,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-updated-element" target="_blank">Abstract Test Case 'Updated element'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-updated-element" target="_blank">Abstract Test Case 'Updated element'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="7d57ba11-1df9-4bb2-aa77-440a313392fd">
@@ -2793,7 +2793,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-crs" target="_blank">Abstract Test Case 'Each entry has CRS information'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-crs" target="_blank">Abstract Test Case 'Each entry has CRS information'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="b84cb78c-b67f-451a-a4b3-510178c03621">
@@ -2849,7 +2849,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-dataset-language" target="_blank">Abstract Test Case 'Language for download link'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-dataset-language" target="_blank">Abstract Test Case 'Language for download link'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="207c5c35-db32-41ba-879e-1e808b7489c6">
@@ -2911,7 +2911,7 @@ INSPIRE registry the value of the 'type' attribute shall be 'text/html'.</li>
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-links-spatial-object-types" target="_blank">Abstract Test Case 'Links for Spatial Object Types'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-links-spatial-object-types" target="_blank">Abstract Test Case 'Links for Spatial Object Types'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="7b0a0bbe-f703-489c-8693-efcaf6161199">
@@ -2980,7 +2980,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-multiple-files" target="_blank">Abstract Test Case 'Multiple links for multiple physical files'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-multiple-files" target="_blank">Abstract Test Case 'Multiple links for multiple physical files'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="34caf1a6-eb2a-449d-9fb0-713f1dc1cabc">
@@ -3041,7 +3041,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-entries" target="_blank">Abstract Test Case 'Separate entries for each format/CRS combination'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-entries" target="_blank">Abstract Test Case 'Separate entries for each format/CRS combination'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="properties" name="Transfer_Properties" id="db77efab-6a81-4e08-814d-cad3b6af1275">
@@ -3235,7 +3235,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-link-media-type" target="_blank">Abstract Test Case 'Use INSPIRE media-types only'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-link-media-type" target="_blank">Abstract Test Case 'Use INSPIRE media-types only'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="properties" name="Transfer_Properties" id="3bda7cfc-b100-44bb-90e6-c3592561f0e1">
@@ -3452,7 +3452,7 @@ Relevant Requirements:
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.1/atom-pre-defined/dataset-feed-multiple-files-description" target="_blank">Abstract Test Case 'Provide guidance for downloading multiple physical files'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/dataset-feed-multiple-files-description" target="_blank">Abstract Test Case 'Provide guidance for downloading multiple physical files'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="httprequest" name="Get Dataset Feed" id="76ab47a4-4bb4-494d-8f01-66088b6ef856">
@@ -4413,7 +4413,7 @@ parameter. The 'Url' element shall have an attribute 'type' with a value of
 </ul>
 <br/>
 <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/3.2/atom-pre-defined/opensearch-description-url-describe-spatial-dataset-operation" target="_blank">Abstract Test Case 'OpenSearch Description URL Describe Spatial Dataset operation'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/download-atom/master/atom-pre-defined/opensearch-description-url-describe-spatial-dataset-operation" target="_blank">Abstract Test Case 'OpenSearch Description URL Describe Spatial Dataset operation'</a>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="OpenSearch Description link exists" id="703f1938-368b-4d87-8015-a91ba132f77f">


### PR DESCRIPTION
Corresponding issue: [#1143](https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1143)