### PR TITLE
CSW, SOS and WMTS getCaseInsensitive undone

### DIFF
--- a/service/dis-csw-core-soapui-project.xml
+++ b/service/dis-csw-core-soapui-project.xml
@@ -1480,7 +1480,7 @@ for (i in languages_to_request){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	for (j in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
+	for (j in ts.testRequest.response.responseHeaders.get('Content-Type')){
 		if (j.contains('xml')){
 			validContentType = true;
 		}
@@ -1604,7 +1604,7 @@ for (i in languages_to_request){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	for (j in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
+	for (j in ts.testRequest.response.responseHeaders.get('Content-Type')){
 		if (j.contains('xml')){
 			validContentType = true;
 		}

--- a/service/dis-csw-core-soapui-project.xml
+++ b/service/dis-csw-core-soapui-project.xml
@@ -2,7 +2,7 @@
 <con:soapui-project id="c837298f-a10e-42d1-88f2-f1415cbbb463" activeEnvironment="Default" name="Conformance Class: Discovery Service - CSW Core" resourceRoot="" soapui-version="5.4.0" abortOnError="false" runType="SEQUENTIAL" xmlns:con="http://eviware.com/soapui/config">
 	<con:description>
 		<![CDATA[This test suite examines an OGC Discovery Service against the requirements related to INSPIRE <br/> <br/> <b>This is a draft version. It has limitations and is expected to contain errors.</b> Please report any issues or problems <a href="https://github.com/INSPIRE-MIF/helpdesk-validator/wiki/Your-feedback" target="_blank">in GitHub</a>. <br/> <br/> Known limitations are documented in the description of the applicable test case or test assertion. <br/> <br/>
-Source: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap" target="_blank">Conformance Class 'Discovery Service CSW'</a>]]>
+Source: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap" target="_blank">Conformance Class 'Discovery Service CSW'</a>]]>
 	</con:description>
 	<con:settings />
 	<con:testSuite id="0c3e1720-dbdf-4970-bb85-f00c3bd75ff1" name="Initialize">
@@ -213,7 +213,7 @@ if(makeInitialRequest){
 		<con:testCase id="afe7b0dd-4860-42c2-9d01-d08a30b77e52" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-07-extended-capabilities" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the service provides the INSPIRE extended metadata.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-07-extended-capabilities" target="_blank">Extended Capabilities</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-07-extended-capabilities" target="_blank">Extended Capabilities</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="dc4dae02-372f-4655-9642-75eb0fe0f447">
@@ -562,7 +562,7 @@ if(scenario == 2){
 		<con:testCase id="88ca47a3-a58d-4e0f-848f-392faf695f07" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-12-discover-resource-matching-query" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the Discover Metadata response contains at least the INSPIRE metadata elements.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-12-discover-resource-matching-query" target="_blank">Discover Resource Matching Query</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-12-discover-resource-matching-query" target="_blank">Discover Resource Matching Query</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="26403505-df57-44d1-9719-27d8633db877">
@@ -703,7 +703,7 @@ getRecordsResponse.SearchResults.children().each{it ->
 		<con:testCase id="40d2cbc1-bbf1-455a-9479-40dbbb2089fa" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-15-link-publish-metadata-operation" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that discovery client approach is implemented properly.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-15-link-publish-metadata-operation" target="_blank">Link Publish Metadata Operation</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-15-link-publish-metadata-operation" target="_blank">Link Publish Metadata Operation</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="782e615e-e922-4d8f-9acc-09489596fb70">
@@ -772,7 +772,7 @@ a.exists(
 		<con:testCase id="2a8dd1b2-1ea8-4d27-b5c3-f57649516631" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-16-link-federated-capabilities-document" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that federated Discovery Service is published in Member State's Discovery Service's capabilities document when the discovery service approach is implemented.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-16-link-federated-capabilities-document" target="_blank">Link Federated Capabilities Document</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-16-link-federated-capabilities-document" target="_blank">Link Federated Capabilities Document</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="6483324c-67a7-4d14-9e48-fdb3c365e039">
@@ -846,7 +846,7 @@ a.exists(
 		<con:testCase id="3b4f5f9b-26b8-4d4d-bd98-9f8c50a7d78b" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-19-query-search-criteria" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the Discover Metadata service supports queryables.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-19-query-search-criteria" target="_blank">Query Search Criteria</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-19-query-search-criteria" target="_blank">Query Search Criteria</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="fdc82c92-1085-434a-95cc-9d85eb68a6ac">
@@ -915,7 +915,7 @@ a.exists(
 		<con:testCase id="fa3c3fe2-c050-4ab9-a30f-c280577982fd" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-20-query-language-parameter" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the Discover Metadata service accepts the language parameter.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-20-query-language-parameter" target="_blank">Query Language Parameter</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-20-query-language-parameter" target="_blank">Query Language Parameter</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="10724f49-3a92-49d6-bf9e-9374002f68ca">
@@ -1143,7 +1143,7 @@ if(getRecordsResponse.SearchResults.size() != 1){
 		<con:testCase id="dce42f1a-2694-4b8d-bee9-6b26af1e0a3c" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-21-query-additional-parameters" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the Discover Metadata service supports additional queryables.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-21-query-additional-parameters" target="_blank">Query Additional Parameters</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-21-query-additional-parameters" target="_blank">Query Additional Parameters</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="ec79067e-6a9e-4168-878a-ceea91f1ef61">
@@ -1212,7 +1212,7 @@ a.exists(
 		<con:testCase id="2d49ae6c-7d6a-4f7c-9a35-611b2a4f5bae" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-22-query-parameters-advertised" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that all ISO and additional queryables are advertised in the capabilities document.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-22-query-parameters-advertised" target="_blank">Query Parameters Advertised</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-22-query-parameters-advertised" target="_blank">Query Parameters Advertised</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="5c7dcf42-4650-42c1-822f-a23330f9359f">
@@ -1266,7 +1266,7 @@ if (missingValues.size() != 0){
 		<con:testCase id="0340ec22-fc88-44ea-9025-b8ad687ab148" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-24-language-natural-lang-fields" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that natural language fields vary depending on the requested language.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-24-language-natural-lang-fields" target="_blank">Language Natural Language Fields</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-24-language-natural-lang-fields" target="_blank">Language Natural Language Fields</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="145e2373-3f63-4a85-af1e-0de351f7aa5f">
@@ -1335,7 +1335,7 @@ a.exists(
 		<con:testCase id="2cc39a22-33b0-432c-b4f3-f9fca0d7fa84" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-25-language-parameter-iso-valid" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the service supports the parameter LANGUAGE.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-25-language-parameter-iso-valid" target="_blank">Language Parameter ISO valid</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-25-language-parameter-iso-valid" target="_blank">Language Parameter ISO valid</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="9b36898f-b5d5-4c57-b75f-349172018bd0">
@@ -1387,7 +1387,7 @@ if(notSupportedLanguage.size() != 0){
 		<con:testCase id="027e7c14-b1ba-41d0-b39f-92c27fab80e4" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-26-language-natural-fields-default" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that natural language fields are provided in default language when requested language is unsupported or absent.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-26-language-natural-fields-default" target="_blank">Language Natural Fields Default</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-26-language-natural-fields-default" target="_blank">Language Natural Fields Default</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="d5d4644d-59e6-492c-8bbf-32575822b69b">
@@ -1507,7 +1507,7 @@ ts.setDisabled(true);
 		<con:testCase id="3f6b71ea-b31b-404b-9356-3ada755def9e" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-27-language-response-value" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the response language is correct based on the requested language.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-27-language-response-value" target="_blank">Language Response Value</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-27-language-response-value" target="_blank">Language Response Value</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="00533e15-68b4-4871-b9ec-a10259b2b696">
@@ -1635,7 +1635,7 @@ ts.setDisabled(true);
 		<con:testCase id="364fcdc7-28ff-4a0d-b4c7-fceeed81f406" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-28-language-supported-default-cardinality" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the cardinality of supported languages is correct.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-28-language-supported-default-cardinality" target="_blank">Language Supported Default Cardinality</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-28-language-supported-default-cardinality" target="_blank">Language Supported Default Cardinality</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="37a81548-14d1-4bed-8936-a1b39c83a7a7">
@@ -1671,7 +1671,7 @@ if(defaultLanguage.size() != 1){
 		<con:testCase id="ed17066c-0557-4428-a72a-e0bbe7dba5e1" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-29-extended-capabilities-schema-valid" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the capabilities document is schema valid.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-29-extended-capabilities-schema-valid" target="_blank">Extended Capabilities Schema Valid</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-29-extended-capabilities-schema-valid" target="_blank">Extended Capabilities Schema Valid</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="3479e631-9ac4-44e2-955c-6e62f5c9e35a">
@@ -1768,7 +1768,7 @@ tsGetObservation.setDisabled(true);
 		<con:testCase id="9e3b0ac3-5909-437b-9017-8338a6fc89d6" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-30-language-getrecords-without-parameter" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test the service behaviour without a language specific filter.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-30-language-getrecords-without-parameter" target="_blank">Language GetRecords without Parameter</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-30-language-getrecords-without-parameter" target="_blank">Language GetRecords without Parameter</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="e8f62b85-dcf8-473a-ae4a-78ce385f202a">
@@ -1867,7 +1867,7 @@ a.exists(
 		<con:testCase id="50c8af6f-8bf0-4b81-9a1e-105b0cbc579e" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-31-language-getrecords-lang-filter" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that the service supports filtering by language.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-31-language-getrecords-lang-filter" target="_blank">Language GetRecords Language Filter</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-31-language-getrecords-lang-filter" target="_blank">Language GetRecords Language Filter</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="7937ffd9-d019-47ef-ab6e-bedfc939436d">
@@ -2025,7 +2025,7 @@ a.exists(
 		<con:testCase id="95597eca-45eb-4105-8e82-837b87263155" failOnError="true" failTestCaseOnErrors="true" keepSession="false" maxResults="0" name="at-32-language-getrecords-exception" searchProperties="true">
 			<con:description>
 				<![CDATA[<p>Test that GetRecords exceptions are provided in the correct language.</p>
-<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/review-ats-csw-3.1/csw-iso-ap/at-32-language-getrecords-exception" target="_blank">Language GetRecords Exception</a></p>]]>
+<p>More information: <a href="http://inspire.ec.europa.eu/id/ats/discovery-service/master/csw-iso-ap/at-32-language-getrecords-exception" target="_blank">Language GetRecords Exception</a></p>]]>
 			</con:description>
 			<con:settings />
 			<con:testStep type="testcasedependency" name="check-initial-testcase" id="917a09f7-083b-492e-902a-83dfaae48689">

--- a/service/ds-sos-pre-defined-soapui-project.xml
+++ b/service/ds-sos-pre-defined-soapui-project.xml
@@ -64,7 +64,7 @@ tsGetObservation.setDisabled(true);
 					<con:assertion type="OwsExceptionReportAssertion" id="136249b8-9f81-4761-be97-74c831c7ad62" name="Fail if service returns OWS Exception Report" />
 					<con:assertion type="GroovyScriptAssertion" id="bbf2023a-6f68-45c7-aec4-620da5a8643a" name="check-content-type">
 						<con:configuration>
-							<scriptText>assert (messageExchange.getResponseHeaders().getCaseInsensitive('Content-Type', 'value').contains('xml'));</scriptText>
+							<scriptText>assert (messageExchange.getResponseHeaders().get('Content-Type', 'value').contains('xml'));</scriptText>
 						</con:configuration>
 					</con:assertion>
 					<con:credentials>

--- a/service/vs-wmts-soapui-project.xml
+++ b/service/vs-wmts-soapui-project.xml
@@ -601,7 +601,7 @@ requestStepList.each{reqStep->
 	
 		httpResponseHeaders = context.testCase.testSteps[reqStep].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
 	
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			
@@ -628,7 +628,7 @@ requestStepList.each{reqStep->
 	
 		httpResponseHeaders = context.testCase.testSteps[reqStep].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 				String[] assertParams = ["parameter", param.toString()];
@@ -1117,12 +1117,12 @@ layers.each{layer->
 
 				def httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 
-				if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') != null &amp;&amp; httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') !=  format.toString()){
+				if(httpResponseHeaders["Content-Type"][0] != null &amp;&amp; httpResponseHeaders["Content-Type"][0] !=  format.toString()){
 					def identifier_tmp = '';
 					if(layer.Identifier.size() == 1){
 						identifier_tmp = layer.Identifier.toString();
 					}
-					String[] assertParams = ["responseformat", httpResponseHeaders.getCaseInsensitive('Content-Type', 'value'), "requestedformat", format.toString(), "layerid", identifier_tmp];
+					String[] assertParams = ["responseformat", httpResponseHeaders["Content-Type"][0].toString(), "requestedformat", format.toString(), "layerid", identifier_tmp];
 					throw new TranslatableAssertionError("TR.wrongResponseFormat", assertParams);
 					//Msg: The response format ({responseformat}) is distinct to the requested format ({requestedformat}) for the '{layerid}' layer.
 				}
@@ -1960,7 +1960,7 @@ supportedLangs.each{lang->
 	
 				httpResponseHeaders = context.testCase.testSteps["http-request-legend"].testRequest.response.responseHeaders;
 	
-				if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value') != format.toString()){
+				if(httpResponseHeaders["Content-Type"][0].toString() != format.toString()){
 					String[] assertParams = ["styleid", style.Identifier.toString(), "layerid", layer.Identifier.toString()];
 					throw new TranslatableAssertionError("TR.wrongLegendResponseFormat", assertParams);
 					//Msg: The response format is wrong for the legend resource into the '{styleid}' style into the '{layerid}' layer.
@@ -2184,7 +2184,7 @@ if(testRunner.testCase.testSuite.project.getPropertyValue("defaultGetTile_Endpoi
 	
 		httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
 	
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			
@@ -2211,7 +2211,7 @@ if(testRunner.testCase.testSuite.project.getPropertyValue("defaultGetTile_Endpoi
 	
 		httpResponseHeaders = context.testCase.testSteps["http-request-gettile"].testRequest.response.responseHeaders;
 	
-		if(httpResponseHeaders.getCaseInsensitive('Content-Type', 'value').contains('text/xml')){
+		if(httpResponseHeaders['Content-Type'][0].contains('text/xml')){
 			def xml_root = new XmlSlurper().parseText(tileResponse);
 			if (!(xml_root.ServiceException.size() == 1 || xml_root.Exception.size() == 1)){
 				String[] assertParams = ["parameter", param.toString()];


### PR DESCRIPTION
Corresponding issue: [#1217](https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1217)