### PR TITLE
WMS at47 and at68 GetCaseInsensitive undone

### DIFF
--- a/service/vs-wms-soapui-project.xml
+++ b/service/vs-wms-soapui-project.xml
@@ -2308,8 +2308,8 @@ for (x in supportedLanguages){
 					testRunner.testCase.setPropertyValue('legendEndpoint', style.LegendURL.OnlineResource.@'xlink:href'.toString());
 					tsGetLegend.setDisabled(false);
 					tsGetLegend.run(testRunner, context);
-					if(tsGetLegend.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')[0] != style.LegendURL.Format.toString()){
-						String[] assertParams = ['Content-Type', tsGetLegend.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type', 'value'), 'LegendURL', style.LegendURL.Format.toString()];
+					if(tsGetLegend.testRequest.response.responseHeaders.get('Content-Type')[0] != style.LegendURL.Format.toString()){
+						String[] assertParams = ['Content-Type', tsGetLegend.testRequest.response.responseHeaders.get('Content-Type', 'value'), 'LegendURL', style.LegendURL.Format.toString()];
 						throw new TranslatableAssertionError("TR.invalidLegendFormat", assertParams);
 					}
 				}
@@ -5441,7 +5441,7 @@ if(defaultLanguage in isoLang){
 	ts.setDisabled(false);
 	ts.run(testRunner, context);
 	def validContentType = false;
-	for (i in ts.testRequest.response.responseHeaders.getCaseInsensitive('Content-Type')){
+	for (i in ts.testRequest.response.responseHeaders.get('Content-Type')){
 		if (i.contains('xml')){
 			validContentType = true;
 		}


### PR DESCRIPTION
Corresponding issue: [#1208](https://github.com/INSPIRE-MIF/helpdesk-validator/issues/1208)